### PR TITLE
Move Context from client argument lists to Client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
@@ -309,7 +309,8 @@ public class Rust2Codegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toParamName(String name) {
-        return underscore(super.toParamName(name));
+        // should be the same as variable name (stolen from RubyClientCodegen)
+        return toVarName(name);
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
@@ -272,7 +272,10 @@ public class Rust2Codegen extends DefaultCodegen implements CodegenConfig {
      */
     @Override
     public String escapeReservedWord(String name) {
-        return "_" + name;  // add an underscore to the name
+        if (this.reservedWordsMappings().containsKey(name)) {
+            return this.reservedWordsMappings().get(name);
+        }
+        return "_" + name; // add an underscore to the name
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/rust2/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/client.mustache
@@ -8,7 +8,7 @@ extern crate chrono;
 use hyper;
 use hyper::client::IntoUrl;
 use hyper::mime;
-use hyper::header::{Headers, ContentType};
+use hyper::header::{Authorization, Headers, ContentType};
 use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
 use hyper::Url;
 use self::hyper_openssl::openssl;
@@ -25,8 +25,8 @@ use std::sync::Arc;
 use std::collections::HashMap;
 #[allow(unused_imports)]
 use swagger;
-
 use swagger::{Context, ApiError, XSpanId};
+use swagger::auth::AuthData;
 
 use {Api{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
      {{operationId}}Response{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
@@ -67,6 +67,22 @@ impl Client {
             base_path: into_base_path(base_path, Some("http"))?,
             hyper_client: Arc::new(hyper::client::Client::new()),
         })
+    }
+
+    pub fn try_new_https_simple<T>(base_path: T)
+                            -> Result<Client, ClientInitError>
+        where T: IntoUrl
+    {
+        // SSL implementation
+        let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls())?;
+        let ssl = hyper_openssl::OpensslClient::from(ssl.build());
+        let connector = hyper::net::HttpsConnector::new(ssl);
+        let hyper_client = hyper::client::Client::with_connector(connector);
+
+        Ok(Client {
+                base_path: into_base_path(base_path, Some("https"))?,
+                hyper_client: Arc::new(hyper_client)
+            })
     }
 
     pub fn try_new_https<T, CA>(base_path: T,
@@ -196,6 +212,13 @@ impl Api for Client {
 
         custom_headers.set(hyper::header::ContentType::json());
 {{/bodyParam}}
+        if let Some(ref auth) = context.auth_data {
+            match auth.clone() {
+                AuthData::Basic(h) => custom_headers.set(Authorization(h)),
+                AuthData::Bearer(h) => custom_headers.set(Authorization(h)),
+                AuthData::ApiKey(h) => custom_headers.set(Authorization(h)),
+            }
+        };
         context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
 {{#headerParams}}{{#-first}}
         // Header parameters

--- a/modules/swagger-codegen/src/main/resources/rust2/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/client.mustache
@@ -57,6 +57,7 @@ fn into_base_path<T: IntoUrl>(input: T, correct_scheme: Option<&'static str>) ->
 pub struct Client {
     base_path: String,
     hyper_client: Arc<hyper::client::Client>,
+    context: Context,
 }
 
 impl Client {
@@ -66,6 +67,7 @@ impl Client {
         Ok(Client {
             base_path: into_base_path(base_path, Some("http"))?,
             hyper_client: Arc::new(hyper::client::Client::new()),
+            context: Context::default(),
         })
     }
 
@@ -81,7 +83,8 @@ impl Client {
 
         Ok(Client {
                 base_path: into_base_path(base_path, Some("https"))?,
-                hyper_client: Arc::new(hyper_client)
+                hyper_client: Arc::new(hyper_client),
+                context: Context::default(),
             })
     }
 
@@ -103,7 +106,8 @@ impl Client {
 
         Ok(Client {
                 base_path: into_base_path(base_path, Some("https"))?,
-                hyper_client: Arc::new(hyper_client)
+                hyper_client: Arc::new(hyper_client),
+                context: Context::default(),
             })
     }
 
@@ -134,7 +138,8 @@ impl Client {
 
         Ok(Client {
                 base_path: into_base_path(base_path, Some("https"))?,
-                hyper_client: Arc::new(hyper_client)
+                hyper_client: Arc::new(hyper_client),
+                context: Context::default(),
             })
     }
 
@@ -155,14 +160,23 @@ impl Client {
     {
         Ok(Client {
             base_path: into_base_path(base_path, None)?,
-            hyper_client: Arc::new(hyper_client)
+            hyper_client: Arc::new(hyper_client),
+            context: Context::default(),
         })
     }
 }
 
 impl Api for Client {
+    fn with_context(&self, context: Context) -> Client {
+        Client {
+            base_path: self.base_path.clone(),
+            hyper_client: self.hyper_client.clone(),
+            context: context,
+        }
+    }
+
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
-    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, param_{{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}, context: &Context) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send> {
+    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, param_{{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send> {
 {{#queryParams}}{{#-first}}
         // Query parameters
 {{/-first}}{{#required}}        let query_{{paramName}} = format!("{{baseName}}={{=<% %>=}}{<% paramName %>}<%={{ }}=%>&", {{paramName}}=param_{{paramName}}{{#isListContainer}}.join(","){{/isListContainer}}{{^isListContainer}}.to_string(){{/isListContainer}});
@@ -212,14 +226,14 @@ impl Api for Client {
 
         custom_headers.set(hyper::header::ContentType::json());
 {{/bodyParam}}
-        if let Some(ref auth) = context.auth_data {
+        if let Some(ref auth) = self.context.auth_data {
             match auth.clone() {
                 AuthData::Basic(h) => custom_headers.set(Authorization(h)),
                 AuthData::Bearer(h) => custom_headers.set(Authorization(h)),
                 AuthData::ApiKey(h) => custom_headers.set(Authorization(h)),
             }
         };
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
+        self.context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
 {{#headerParams}}{{#-first}}
         // Header parameters
 

--- a/modules/swagger-codegen/src/main/resources/rust2/lib.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/lib.mustache
@@ -38,9 +38,10 @@ pub enum {{operationId}}Response {
 
 
 pub trait Api {
+    fn with_context(&self, context: Context) -> Client;
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
-    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}, context: &Context) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send>;
+    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send>;
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 

--- a/modules/swagger-codegen/src/main/resources/rust2/server.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/server.mustache
@@ -204,7 +204,7 @@ fn add_routes<T>(router: &mut Router, api: T) where T: Api + Send + Sync + Clone
     {{/isFormParam}}
 {{/allParams}}
 
-                match api.{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}param_{{paramName}}{{#isListContainer}}.as_ref(){{/isListContainer}}, {{/allParams}}context).wait() {
+                match api.{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}param_{{paramName}}{{#isListContainer}}.as_ref(){{/isListContainer}}, {{/allParams}}).wait() {
                     Ok(rsp) => match rsp {
 {{#responses}}
                         {{operationId}}Response::{{message}}{{#dataType}}{{^headers}}(body){{/headers}}{{#headers}}{{#-first}}{ body{{/-first}}{{/headers}}{{/dataType}}{{#headers}}{{#-first}}{{^dataType}}{ {{/dataType}}{{#dataType}}, {{/dataType}}{{/-first}}{{^-first}}, {{/-first}}{{name}}{{#-last}} }{{/-last}}{{/headers}} => {


### PR DESCRIPTION
The Client side of this looks right to me. I'm opening this pull request just to give you a look at the approach I'm experimenting with. I do not expect you to merge this!

I made a small change to `server` to get the resulting code to compile. I have no doubt that the server code is incorrect. I do not understand the server code well enough to know what direction to take it.

I have not addressed the examples.

This bundles in the commits I have in other open pull requests, mainly for my convenience.