### PR TITLE
Allow `Context` to be bound to `Api`, and not passed on every function call

### DIFF
--- a/modules/swagger-codegen/src/main/resources/rust2/Cargo.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/Cargo.mustache
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_ignored = {version = "0.0.4", optional = true}
 serde_json = {version = "1.0", optional = true}
-swagger = "0.6"
+swagger = {git = "https://github.com/Metaswitch/swagger-rs.git", branch = "optional-context"}
 urlencoded = {version = "0.5", optional = true}
 uuid = {version = "0.5", optional = true, features = ["serde", "v4"]}
 # ToDo: this should be updated to point at the official crate once

--- a/modules/swagger-codegen/src/main/resources/rust2/example-client.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/example-client.mustache
@@ -12,7 +12,7 @@ extern crate clap;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use {{externCrateName}}::{Api,
+use {{externCrateName}}::{ApiNoContext, ContextWrapperExt,
                       ApiError{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
                       {{operationId}}Response{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
                      };
@@ -39,15 +39,14 @@ fn main() {
         // Using HTTP
         {{externCrateName}}::Client::try_new_http("http://localhost:{{serverPort}}").expect("Failed to create HTTP client")
     };
+    let client = client.with_context({{externCrateName}}::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string()));
 
     match matches.value_of("operation") {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
         {{#vendorExtensions}}{{#noClientExample}}// Disabled because there's no example.
         // {{/noClientExample}}Some("{{operationId}}") => {
-        {{#noClientExample}}// {{/noClientExample}}    // Using a non-default `Context` is not required; this is just an example!
-        {{#noClientExample}}// {{/noClientExample}}    let context = {{externCrateName}}::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        {{#noClientExample}}// {{/noClientExample}}    let result = client.{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{#vendorExtensions}}{{{example}}}{{/vendorExtensions}}, {{/allParams}}&context).wait();
-        {{#vendorExtensions}}{{#noClientExample}}// {{/noClientExample}}{{/vendorExtensions}}    println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        {{#noClientExample}}// {{/noClientExample}}    let result = client.{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{^-first}}, {{/-first}}{{#vendorExtensions}}{{{example}}}{{/vendorExtensions}}{{/allParams}}).wait();
+        {{#vendorExtensions}}{{#noClientExample}}// {{/noClientExample}}{{/vendorExtensions}}    println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         {{#vendorExtensions}}{{#noClientExample}}// {{/noClientExample}}{{/vendorExtensions}} },
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
         _ => {

--- a/modules/swagger-codegen/src/main/resources/rust2/lib.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/lib.mustache
@@ -49,6 +49,52 @@ pub trait Api {
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 
+pub trait ApiNoContext {
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
+{{#summary}}    /// {{{summary}}}{{/summary}}
+    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send>;
+{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+}
+
+pub struct ContextWrapper<T> {
+    api: T,
+    context: Context,
+}
+
+impl<T> ContextWrapper<T> {
+    pub fn new(api: T, context: Context) -> ContextWrapper<T> {
+        ContextWrapper{api, context}
+    }
+}
+
+trait ContextWrapperExt<T> {
+    fn with_context(self, context: Context) -> ContextWrapper<T>;
+}
+
+impl<T: Api> ContextWrapperExt<T> for T {
+    fn with_context(self, context: Context) -> ContextWrapper<T> {
+        ContextWrapper::<T>::new(self, context)
+    }
+}
+
+impl<T: Api> ApiNoContext for ContextWrapper<T> {
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
+{{#summary}}    /// {{{summary}}}{{/summary}}
+    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send> {
+        self.api.{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{paramName}}, {{/allParams}}&self.context)
+    }
+{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+}
+
+impl<T: ApiNoContext> Api for T {
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
+{{#summary}}    /// {{{summary}}}{{/summary}}
+    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}, _: &Context) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send> {
+        self.{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{paramName}}, {{/allParams}})
+    }
+{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+}
+
 #[cfg(feature = "client")]
 pub mod client;
 

--- a/modules/swagger-codegen/src/main/resources/rust2/lib.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust2/lib.mustache
@@ -30,7 +30,7 @@ pub use futures::Future;
 #[cfg(any(feature = "client", feature = "server"))]
 mod mimetypes;
 
-pub use swagger::{ApiError, Context, XSpanId};
+pub use swagger::{ApiError, Context, ContextWrapper};
 
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{^isResponseFile}}
@@ -42,6 +42,7 @@ pub enum {{operationId}}Response {
 }
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
+/// API
 pub trait Api {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
@@ -49,6 +50,7 @@ pub trait Api {
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 
+/// API without a `Context`
 pub trait ApiNoContext {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
@@ -56,41 +58,23 @@ pub trait ApiNoContext {
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 
-pub struct ContextWrapper<T> {
-    api: T,
-    context: Context,
+/// Trait to extend an API to make it easy to bind it to a context.
+pub trait ContextWrapperExt<'a> where Self: Sized {
+    /// Binds this API to a context.
+    fn with_context(self: &'a Self, context: Context) -> ContextWrapper<'a, Self>;
 }
 
-impl<T> ContextWrapper<T> {
-    pub fn new(api: T, context: Context) -> ContextWrapper<T> {
-        ContextWrapper{api, context}
+impl<'a, T: Api + Sized> ContextWrapperExt<'a> for T {
+    fn with_context(self: &'a T, context: Context) -> ContextWrapper<'a, T> {
+         ContextWrapper::<T>::new(self, context)
     }
 }
 
-trait ContextWrapperExt<T> {
-    fn with_context(self, context: Context) -> ContextWrapper<T>;
-}
-
-impl<T: Api> ContextWrapperExt<T> for T {
-    fn with_context(self, context: Context) -> ContextWrapper<T> {
-        ContextWrapper::<T>::new(self, context)
-    }
-}
-
-impl<T: Api> ApiNoContext for ContextWrapper<T> {
+impl<'a, T: Api> ApiNoContext for ContextWrapper<'a, T> {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
     fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send> {
-        self.api.{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{paramName}}, {{/allParams}}&self.context)
-    }
-{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
-}
-
-impl<T: ApiNoContext> Api for T {
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
-{{#summary}}    /// {{{summary}}}{{/summary}}
-    fn {{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}(&self{{#allParams}}, {{paramName}}: {{^required}}{{#isFile}}Box<Future<Item={{/isFile}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{#isFile}}, Error=Error> + Send>{{/isFile}}{{/required}}{{/allParams}}, _: &Context) -> Box<Future<Item={{operationId}}Response, Error=ApiError> + Send> {
-        self.{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{paramName}}, {{/allParams}})
+        self.api().{{#vendorExtensions}}{{operation_id}}{{/vendorExtensions}}({{#allParams}}{{paramName}}, {{/allParams}}&self.context())
     }
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }

--- a/samples/client/petstore/rust2/Cargo.toml
+++ b/samples/client/petstore/rust2/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_ignored = {version = "0.0.4", optional = true}
 serde_json = {version = "1.0", optional = true}
-swagger = "0.6"
+swagger = {git = "https://github.com/Metaswitch/swagger-rs.git", branch = "optional-context"}
 urlencoded = {version = "0.5", optional = true}
 uuid = {version = "0.5", optional = true, features = ["serde", "v4"]}
 # ToDo: this should be updated to point at the official crate once

--- a/samples/client/petstore/rust2/README.md
+++ b/samples/client/petstore/rust2/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.0.0
-- Build date: 2017-09-26T16:36:55.563+01:00
+- Build date: 2017-09-26T21:38:28.989+01:00
 
 ## Examples
 

--- a/samples/client/petstore/rust2/examples/client.rs
+++ b/samples/client/petstore/rust2/examples/client.rs
@@ -12,7 +12,7 @@ extern crate clap;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use petstore_api::{Api,
+use petstore_api::{ApiNoContext, ContextWrapperExt,
                       ApiError,
                       TestSpecialTagsResponse,
                       GetXmlFeaturesResponse,
@@ -92,240 +92,177 @@ fn main() {
         // Using HTTP
         petstore_api::Client::try_new_http("http://localhost:8080").expect("Failed to create HTTP client")
     };
+    let client = client.with_context(petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string()));
 
     match matches.value_of("operation") {
 
         // Disabled because there's no example.
         // Some("TestSpecialTags") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.test_special_tags(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.test_special_tags(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         Some("GetXmlFeatures") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.get_xml_features(&context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.get_xml_features().wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         // Disabled because there's no example.
         // Some("PostXmlFeatures") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.post_xml_features(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.post_xml_features(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         Some("FakeOuterBooleanSerialize") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.fake_outer_boolean_serialize(None, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.fake_outer_boolean_serialize(None).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("FakeOuterCompositeSerialize") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.fake_outer_composite_serialize(None, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.fake_outer_composite_serialize(None).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("FakeOuterNumberSerialize") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.fake_outer_number_serialize(None, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.fake_outer_number_serialize(None).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("FakeOuterStringSerialize") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.fake_outer_string_serialize(None, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.fake_outer_string_serialize(None).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         // Disabled because there's no example.
         // Some("TestClientModel") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.test_client_model(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.test_client_model(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         Some("TestEndpointParameters") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.test_endpoint_parameters(3.4, 1.2, "pattern_without_delimiter_example".to_string(), swagger::ByteArray("byte_example".to_string().into_bytes()), Some(56), Some(56), Some(789), Some(3.4), Some("string_example".to_string()), Some(swagger::ByteArray(Vec::from("B"))), None, None, Some("password_example".to_string()), Some("callback_example".to_string()), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.test_endpoint_parameters(3.4, 1.2, "pattern_without_delimiter_example".to_string(), swagger::ByteArray("byte_example".to_string().into_bytes()), Some(56), Some(56), Some(789), Some(3.4), Some("string_example".to_string()), Some(swagger::ByteArray(Vec::from("B"))), None, None, Some("password_example".to_string()), Some("callback_example".to_string())).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("TestEnumParameters") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.test_enum_parameters(Some(&Vec::new()), Some("enum_form_string_example".to_string()), Some(&Vec::new()), Some("enum_header_string_example".to_string()), Some(&Vec::new()), Some("enum_query_string_example".to_string()), Some(56), Some(1.2), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.test_enum_parameters(Some(&Vec::new()), Some("enum_form_string_example".to_string()), Some(&Vec::new()), Some("enum_header_string_example".to_string()), Some(&Vec::new()), Some("enum_query_string_example".to_string()), Some(56), Some(1.2)).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("TestJsonFormData") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.test_json_form_data("param_example".to_string(), "param2_example".to_string(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.test_json_form_data("param_example".to_string(), "param2_example".to_string()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         // Disabled because there's no example.
         // Some("TestClassname") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.test_classname(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.test_classname(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         // Disabled because there's no example.
         // Some("AddPet") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.add_pet(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.add_pet(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         Some("DeletePet") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.delete_pet(789, Some("api_key_example".to_string()), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.delete_pet(789, Some("api_key_example".to_string())).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("FindPetsByStatus") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.find_pets_by_status(&Vec::new(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.find_pets_by_status(&Vec::new()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("FindPetsByTags") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.find_pets_by_tags(&Vec::new(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.find_pets_by_tags(&Vec::new()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("GetPetById") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.get_pet_by_id(789, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.get_pet_by_id(789).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         // Disabled because there's no example.
         // Some("UpdatePet") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.update_pet(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.update_pet(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         Some("UpdatePetWithForm") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.update_pet_with_form(789, Some("name_example".to_string()), Some("status_example".to_string()), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.update_pet_with_form(789, Some("name_example".to_string()), Some("status_example".to_string())).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("UploadFile") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.upload_file(789, Some("additional_metadata_example".to_string()), Box::new(future::ok(Some(Box::new(stream::once(Ok(b"hello".to_vec()))) as Box<Stream<Item=_, Error=_> + Send>))) as Box<Future<Item=_, Error=_> + Send>, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.upload_file(789, Some("additional_metadata_example".to_string()), Box::new(future::ok(Some(Box::new(stream::once(Ok(b"hello".to_vec()))) as Box<Stream<Item=_, Error=_> + Send>))) as Box<Future<Item=_, Error=_> + Send>).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("DeleteOrder") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.delete_order("order_id_example".to_string(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.delete_order("order_id_example".to_string()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("GetInventory") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.get_inventory(&context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.get_inventory().wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("GetOrderById") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.get_order_by_id(789, &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.get_order_by_id(789).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         // Disabled because there's no example.
         // Some("PlaceOrder") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.place_order(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.place_order(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         // Disabled because there's no example.
         // Some("CreateUser") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.create_user(???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.create_user(???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         Some("CreateUsersWithArrayInput") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.create_users_with_array_input(&Vec::new(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.create_users_with_array_input(&Vec::new()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("CreateUsersWithListInput") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.create_users_with_list_input(&Vec::new(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.create_users_with_list_input(&Vec::new()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("DeleteUser") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.delete_user("username_example".to_string(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.delete_user("username_example".to_string()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("GetUserByName") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.get_user_by_name("username_example".to_string(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.get_user_by_name("username_example".to_string()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("LoginUser") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.login_user("username_example".to_string(), "password_example".to_string(), &context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.login_user("username_example".to_string(), "password_example".to_string()).wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         Some("LogoutUser") => {
-            // Using a non-default `Context` is not required; this is just an example!
-            let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-            let result = client.logout_user(&context).wait();
-            println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+            let result = client.logout_user().wait();
+            println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
          },
 
         // Disabled because there's no example.
         // Some("UpdateUser") => {
-        //     // Using a non-default `Context` is not required; this is just an example!
-        //     let context = petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string());
-        //     let result = client.update_user("username_example".to_string(), ???, &context).wait();
-        //     println!("{:?} (X-Span-ID: {:?})", result, context.x_span_id.unwrap_or(String::from("<none>")).clone());
+        //     let result = client.update_user("username_example".to_string(), ???).wait();
+        //     println!("{:?} (X-Span-ID: {:?})", result, client.context().x_span_id.clone().unwrap_or(String::from("<none>")));
         //  },
 
         _ => {

--- a/samples/client/petstore/rust2/src/lib.rs
+++ b/samples/client/petstore/rust2/src/lib.rs
@@ -311,6 +311,416 @@ pub trait Api {
 
 }
 
+pub trait ApiNoContext {
+
+
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send>;
+
+
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send>;
+
+
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send>;
+
+
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send>;
+
+    /// To test \"client\" model
+    fn test_client_model(&self, body: models::Client) -> Box<Future<Item=TestClientModelResponse, Error=ApiError> + Send>;
+
+    /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send>;
+
+    /// To test enum parameters
+    fn test_enum_parameters(&self, enum_form_string_array: Option<&Vec<String>>, enum_form_string: Option<String>, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError> + Send>;
+
+    /// test json serialization of form data
+    fn test_json_form_data(&self, param: String, param2: String) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send>;
+
+    /// To test class name in snake case
+    fn test_classname(&self, body: models::Client) -> Box<Future<Item=TestClassnameResponse, Error=ApiError> + Send>;
+
+    /// Add a new pet to the store
+    fn add_pet(&self, body: models::Pet) -> Box<Future<Item=AddPetResponse, Error=ApiError> + Send>;
+
+    /// Deletes a pet
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<Future<Item=DeletePetResponse, Error=ApiError> + Send>;
+
+    /// Finds Pets by status
+    fn find_pets_by_status(&self, status: &Vec<String>) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send>;
+
+    /// Finds Pets by tags
+    fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send>;
+
+    /// Find pet by ID
+    fn get_pet_by_id(&self, pet_id: i64) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError> + Send>;
+
+    /// Update an existing pet
+    fn update_pet(&self, body: models::Pet) -> Box<Future<Item=UpdatePetResponse, Error=ApiError> + Send>;
+
+    /// Updates a pet in the store with form data
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send>;
+
+    /// uploads an image
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Box<Future<Item=Option<Box<Stream<Item=Vec<u8>, Error=Error> + Send>>, Error=Error> + Send>) -> Box<Future<Item=UploadFileResponse, Error=ApiError> + Send>;
+
+    /// Delete purchase order by ID
+    fn delete_order(&self, order_id: String) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError> + Send>;
+
+    /// Returns pet inventories by status
+    fn get_inventory(&self) -> Box<Future<Item=GetInventoryResponse, Error=ApiError> + Send>;
+
+    /// Find purchase order by ID
+    fn get_order_by_id(&self, order_id: i64) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError> + Send>;
+
+    /// Place an order for a pet
+    fn place_order(&self, body: models::Order) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError> + Send>;
+
+    /// Create user
+    fn create_user(&self, body: models::User) -> Box<Future<Item=CreateUserResponse, Error=ApiError> + Send>;
+
+    /// Creates list of users with given input array
+    fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send>;
+
+    /// Creates list of users with given input array
+    fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send>;
+
+    /// Delete user
+    fn delete_user(&self, username: String) -> Box<Future<Item=DeleteUserResponse, Error=ApiError> + Send>;
+
+    /// Get user by user name
+    fn get_user_by_name(&self, username: String) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError> + Send>;
+
+    /// Logs user into the system
+    fn login_user(&self, username: String, password: String) -> Box<Future<Item=LoginUserResponse, Error=ApiError> + Send>;
+
+    /// Logs out current logged in user session
+    fn logout_user(&self) -> Box<Future<Item=LogoutUserResponse, Error=ApiError> + Send>;
+
+    /// Updated user
+    fn update_user(&self, username: String, body: models::User) -> Box<Future<Item=UpdateUserResponse, Error=ApiError> + Send>;
+
+}
+
+pub struct ContextWrapper<T> {
+    api: T,
+    context: Context,
+}
+
+impl<T> ContextWrapper<T> {
+    pub fn new(api: T, context: Context) -> ContextWrapper<T> {
+        ContextWrapper{api, context}
+    }
+}
+
+trait ContextWrapperExt<T> {
+    fn with_context(self, context: Context) -> ContextWrapper<T>;
+}
+
+impl<T: Api> ContextWrapperExt<T> for T {
+    fn with_context(self, context: Context) -> ContextWrapper<T> {
+        ContextWrapper::<T>::new(self, context)
+    }
+}
+
+impl<T: Api> ApiNoContext for ContextWrapper<T> {
+
+
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send> {
+        self.api.fake_outer_boolean_serialize(body, &self.context)
+    }
+
+
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send> {
+        self.api.fake_outer_composite_serialize(body, &self.context)
+    }
+
+
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send> {
+        self.api.fake_outer_number_serialize(body, &self.context)
+    }
+
+
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send> {
+        self.api.fake_outer_string_serialize(body, &self.context)
+    }
+
+    /// To test \"client\" model
+    fn test_client_model(&self, body: models::Client) -> Box<Future<Item=TestClientModelResponse, Error=ApiError> + Send> {
+        self.api.test_client_model(body, &self.context)
+    }
+
+    /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send> {
+        self.api.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, &self.context)
+    }
+
+    /// To test enum parameters
+    fn test_enum_parameters(&self, enum_form_string_array: Option<&Vec<String>>, enum_form_string: Option<String>, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError> + Send> {
+        self.api.test_enum_parameters(enum_form_string_array, enum_form_string, enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, &self.context)
+    }
+
+    /// test json serialization of form data
+    fn test_json_form_data(&self, param: String, param2: String) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send> {
+        self.api.test_json_form_data(param, param2, &self.context)
+    }
+
+    /// To test class name in snake case
+    fn test_classname(&self, body: models::Client) -> Box<Future<Item=TestClassnameResponse, Error=ApiError> + Send> {
+        self.api.test_classname(body, &self.context)
+    }
+
+    /// Add a new pet to the store
+    fn add_pet(&self, body: models::Pet) -> Box<Future<Item=AddPetResponse, Error=ApiError> + Send> {
+        self.api.add_pet(body, &self.context)
+    }
+
+    /// Deletes a pet
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<Future<Item=DeletePetResponse, Error=ApiError> + Send> {
+        self.api.delete_pet(pet_id, api_key, &self.context)
+    }
+
+    /// Finds Pets by status
+    fn find_pets_by_status(&self, status: &Vec<String>) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send> {
+        self.api.find_pets_by_status(status, &self.context)
+    }
+
+    /// Finds Pets by tags
+    fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send> {
+        self.api.find_pets_by_tags(tags, &self.context)
+    }
+
+    /// Find pet by ID
+    fn get_pet_by_id(&self, pet_id: i64) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError> + Send> {
+        self.api.get_pet_by_id(pet_id, &self.context)
+    }
+
+    /// Update an existing pet
+    fn update_pet(&self, body: models::Pet) -> Box<Future<Item=UpdatePetResponse, Error=ApiError> + Send> {
+        self.api.update_pet(body, &self.context)
+    }
+
+    /// Updates a pet in the store with form data
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send> {
+        self.api.update_pet_with_form(pet_id, name, status, &self.context)
+    }
+
+    /// uploads an image
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Box<Future<Item=Option<Box<Stream<Item=Vec<u8>, Error=Error> + Send>>, Error=Error> + Send>) -> Box<Future<Item=UploadFileResponse, Error=ApiError> + Send> {
+        self.api.upload_file(pet_id, additional_metadata, file, &self.context)
+    }
+
+    /// Delete purchase order by ID
+    fn delete_order(&self, order_id: String) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError> + Send> {
+        self.api.delete_order(order_id, &self.context)
+    }
+
+    /// Returns pet inventories by status
+    fn get_inventory(&self) -> Box<Future<Item=GetInventoryResponse, Error=ApiError> + Send> {
+        self.api.get_inventory(&self.context)
+    }
+
+    /// Find purchase order by ID
+    fn get_order_by_id(&self, order_id: i64) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError> + Send> {
+        self.api.get_order_by_id(order_id, &self.context)
+    }
+
+    /// Place an order for a pet
+    fn place_order(&self, body: models::Order) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError> + Send> {
+        self.api.place_order(body, &self.context)
+    }
+
+    /// Create user
+    fn create_user(&self, body: models::User) -> Box<Future<Item=CreateUserResponse, Error=ApiError> + Send> {
+        self.api.create_user(body, &self.context)
+    }
+
+    /// Creates list of users with given input array
+    fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send> {
+        self.api.create_users_with_array_input(body, &self.context)
+    }
+
+    /// Creates list of users with given input array
+    fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send> {
+        self.api.create_users_with_list_input(body, &self.context)
+    }
+
+    /// Delete user
+    fn delete_user(&self, username: String) -> Box<Future<Item=DeleteUserResponse, Error=ApiError> + Send> {
+        self.api.delete_user(username, &self.context)
+    }
+
+    /// Get user by user name
+    fn get_user_by_name(&self, username: String) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError> + Send> {
+        self.api.get_user_by_name(username, &self.context)
+    }
+
+    /// Logs user into the system
+    fn login_user(&self, username: String, password: String) -> Box<Future<Item=LoginUserResponse, Error=ApiError> + Send> {
+        self.api.login_user(username, password, &self.context)
+    }
+
+    /// Logs out current logged in user session
+    fn logout_user(&self) -> Box<Future<Item=LogoutUserResponse, Error=ApiError> + Send> {
+        self.api.logout_user(&self.context)
+    }
+
+    /// Updated user
+    fn update_user(&self, username: String, body: models::User) -> Box<Future<Item=UpdateUserResponse, Error=ApiError> + Send> {
+        self.api.update_user(username, body, &self.context)
+    }
+
+}
+
+impl<T: ApiNoContext> Api for T {
+
+
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>, _: &Context) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send> {
+        self.fake_outer_boolean_serialize(body, )
+    }
+
+
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>, _: &Context) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send> {
+        self.fake_outer_composite_serialize(body, )
+    }
+
+
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>, _: &Context) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send> {
+        self.fake_outer_number_serialize(body, )
+    }
+
+
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, _: &Context) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send> {
+        self.fake_outer_string_serialize(body, )
+    }
+
+    /// To test \"client\" model
+    fn test_client_model(&self, body: models::Client, _: &Context) -> Box<Future<Item=TestClientModelResponse, Error=ApiError> + Send> {
+        self.test_client_model(body, )
+    }
+
+    /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>, _: &Context) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send> {
+        self.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, )
+    }
+
+    /// To test enum parameters
+    fn test_enum_parameters(&self, enum_form_string_array: Option<&Vec<String>>, enum_form_string: Option<String>, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, _: &Context) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError> + Send> {
+        self.test_enum_parameters(enum_form_string_array, enum_form_string, enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, )
+    }
+
+    /// test json serialization of form data
+    fn test_json_form_data(&self, param: String, param2: String, _: &Context) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send> {
+        self.test_json_form_data(param, param2, )
+    }
+
+    /// To test class name in snake case
+    fn test_classname(&self, body: models::Client, _: &Context) -> Box<Future<Item=TestClassnameResponse, Error=ApiError> + Send> {
+        self.test_classname(body, )
+    }
+
+    /// Add a new pet to the store
+    fn add_pet(&self, body: models::Pet, _: &Context) -> Box<Future<Item=AddPetResponse, Error=ApiError> + Send> {
+        self.add_pet(body, )
+    }
+
+    /// Deletes a pet
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>, _: &Context) -> Box<Future<Item=DeletePetResponse, Error=ApiError> + Send> {
+        self.delete_pet(pet_id, api_key, )
+    }
+
+    /// Finds Pets by status
+    fn find_pets_by_status(&self, status: &Vec<String>, _: &Context) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send> {
+        self.find_pets_by_status(status, )
+    }
+
+    /// Finds Pets by tags
+    fn find_pets_by_tags(&self, tags: &Vec<String>, _: &Context) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send> {
+        self.find_pets_by_tags(tags, )
+    }
+
+    /// Find pet by ID
+    fn get_pet_by_id(&self, pet_id: i64, _: &Context) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError> + Send> {
+        self.get_pet_by_id(pet_id, )
+    }
+
+    /// Update an existing pet
+    fn update_pet(&self, body: models::Pet, _: &Context) -> Box<Future<Item=UpdatePetResponse, Error=ApiError> + Send> {
+        self.update_pet(body, )
+    }
+
+    /// Updates a pet in the store with form data
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>, _: &Context) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send> {
+        self.update_pet_with_form(pet_id, name, status, )
+    }
+
+    /// uploads an image
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Box<Future<Item=Option<Box<Stream<Item=Vec<u8>, Error=Error> + Send>>, Error=Error> + Send>, _: &Context) -> Box<Future<Item=UploadFileResponse, Error=ApiError> + Send> {
+        self.upload_file(pet_id, additional_metadata, file, )
+    }
+
+    /// Delete purchase order by ID
+    fn delete_order(&self, order_id: String, _: &Context) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError> + Send> {
+        self.delete_order(order_id, )
+    }
+
+    /// Returns pet inventories by status
+    fn get_inventory(&self, _: &Context) -> Box<Future<Item=GetInventoryResponse, Error=ApiError> + Send> {
+        self.get_inventory()
+    }
+
+    /// Find purchase order by ID
+    fn get_order_by_id(&self, order_id: i64, _: &Context) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError> + Send> {
+        self.get_order_by_id(order_id, )
+    }
+
+    /// Place an order for a pet
+    fn place_order(&self, body: models::Order, _: &Context) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError> + Send> {
+        self.place_order(body, )
+    }
+
+    /// Create user
+    fn create_user(&self, body: models::User, _: &Context) -> Box<Future<Item=CreateUserResponse, Error=ApiError> + Send> {
+        self.create_user(body, )
+    }
+
+    /// Creates list of users with given input array
+    fn create_users_with_array_input(&self, body: &Vec<models::User>, _: &Context) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send> {
+        self.create_users_with_array_input(body, )
+    }
+
+    /// Creates list of users with given input array
+    fn create_users_with_list_input(&self, body: &Vec<models::User>, _: &Context) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send> {
+        self.create_users_with_list_input(body, )
+    }
+
+    /// Delete user
+    fn delete_user(&self, username: String, _: &Context) -> Box<Future<Item=DeleteUserResponse, Error=ApiError> + Send> {
+        self.delete_user(username, )
+    }
+
+    /// Get user by user name
+    fn get_user_by_name(&self, username: String, _: &Context) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError> + Send> {
+        self.get_user_by_name(username, )
+    }
+
+    /// Logs user into the system
+    fn login_user(&self, username: String, password: String, _: &Context) -> Box<Future<Item=LoginUserResponse, Error=ApiError> + Send> {
+        self.login_user(username, password, )
+    }
+
+    /// Logs out current logged in user session
+    fn logout_user(&self, _: &Context) -> Box<Future<Item=LogoutUserResponse, Error=ApiError> + Send> {
+        self.logout_user()
+    }
+
+    /// Updated user
+    fn update_user(&self, username: String, body: models::User, _: &Context) -> Box<Future<Item=UpdateUserResponse, Error=ApiError> + Send> {
+        self.update_user(username, body, )
+    }
+
+}
+
 #[cfg(feature = "client")]
 pub mod client;
 

--- a/samples/client/petstore/rust2/src/lib.rs
+++ b/samples/client/petstore/rust2/src/lib.rs
@@ -30,7 +30,7 @@ pub use futures::Future;
 #[cfg(any(feature = "client", feature = "server"))]
 mod mimetypes;
 
-pub use swagger::{ApiError, Context, XSpanId};
+pub use swagger::{ApiError, Context, ContextWrapper};
 
 
 #[derive(Debug, PartialEq)]
@@ -211,6 +211,7 @@ pub enum UpdateUserResponse {
 }
 
 
+/// API
 pub trait Api {
 
     /// To test special tags
@@ -311,7 +312,17 @@ pub trait Api {
 
 }
 
+/// API without a `Context`
 pub trait ApiNoContext {
+
+    /// To test special tags
+    fn test_special_tags(&self, body: models::Client) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError> + Send>;
+
+    /// Get some XML
+    fn get_xml_features(&self) -> Box<Future<Item=GetXmlFeaturesResponse, Error=ApiError> + Send>;
+
+    /// Post some xml
+    fn post_xml_features(&self, xml_object: models::XmlObject) -> Box<Future<Item=PostXmlFeaturesResponse, Error=ApiError> + Send>;
 
 
     fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send>;
@@ -402,321 +413,178 @@ pub trait ApiNoContext {
 
 }
 
-pub struct ContextWrapper<T> {
-    api: T,
-    context: Context,
+/// Trait to extend an API to make it easy to bind it to a context.
+pub trait ContextWrapperExt<'a> where Self: Sized {
+    /// Binds this API to a context.
+    fn with_context(self: &'a Self, context: Context) -> ContextWrapper<'a, Self>;
 }
 
-impl<T> ContextWrapper<T> {
-    pub fn new(api: T, context: Context) -> ContextWrapper<T> {
-        ContextWrapper{api, context}
+impl<'a, T: Api + Sized> ContextWrapperExt<'a> for T {
+    fn with_context(self: &'a T, context: Context) -> ContextWrapper<'a, T> {
+         ContextWrapper::<T>::new(self, context)
     }
 }
 
-trait ContextWrapperExt<T> {
-    fn with_context(self, context: Context) -> ContextWrapper<T>;
-}
+impl<'a, T: Api> ApiNoContext for ContextWrapper<'a, T> {
 
-impl<T: Api> ContextWrapperExt<T> for T {
-    fn with_context(self, context: Context) -> ContextWrapper<T> {
-        ContextWrapper::<T>::new(self, context)
+    /// To test special tags
+    fn test_special_tags(&self, body: models::Client) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError> + Send> {
+        self.api().test_special_tags(body, &self.context())
     }
-}
 
-impl<T: Api> ApiNoContext for ContextWrapper<T> {
+    /// Get some XML
+    fn get_xml_features(&self) -> Box<Future<Item=GetXmlFeaturesResponse, Error=ApiError> + Send> {
+        self.api().get_xml_features(&self.context())
+    }
+
+    /// Post some xml
+    fn post_xml_features(&self, xml_object: models::XmlObject) -> Box<Future<Item=PostXmlFeaturesResponse, Error=ApiError> + Send> {
+        self.api().post_xml_features(xml_object, &self.context())
+    }
 
 
     fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send> {
-        self.api.fake_outer_boolean_serialize(body, &self.context)
+        self.api().fake_outer_boolean_serialize(body, &self.context())
     }
 
 
     fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send> {
-        self.api.fake_outer_composite_serialize(body, &self.context)
+        self.api().fake_outer_composite_serialize(body, &self.context())
     }
 
 
     fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send> {
-        self.api.fake_outer_number_serialize(body, &self.context)
+        self.api().fake_outer_number_serialize(body, &self.context())
     }
 
 
     fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send> {
-        self.api.fake_outer_string_serialize(body, &self.context)
+        self.api().fake_outer_string_serialize(body, &self.context())
     }
 
     /// To test \"client\" model
     fn test_client_model(&self, body: models::Client) -> Box<Future<Item=TestClientModelResponse, Error=ApiError> + Send> {
-        self.api.test_client_model(body, &self.context)
+        self.api().test_client_model(body, &self.context())
     }
 
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
     fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send> {
-        self.api.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, &self.context)
+        self.api().test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, &self.context())
     }
 
     /// To test enum parameters
     fn test_enum_parameters(&self, enum_form_string_array: Option<&Vec<String>>, enum_form_string: Option<String>, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError> + Send> {
-        self.api.test_enum_parameters(enum_form_string_array, enum_form_string, enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, &self.context)
+        self.api().test_enum_parameters(enum_form_string_array, enum_form_string, enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, &self.context())
     }
 
     /// test json serialization of form data
     fn test_json_form_data(&self, param: String, param2: String) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send> {
-        self.api.test_json_form_data(param, param2, &self.context)
+        self.api().test_json_form_data(param, param2, &self.context())
     }
 
     /// To test class name in snake case
     fn test_classname(&self, body: models::Client) -> Box<Future<Item=TestClassnameResponse, Error=ApiError> + Send> {
-        self.api.test_classname(body, &self.context)
+        self.api().test_classname(body, &self.context())
     }
 
     /// Add a new pet to the store
     fn add_pet(&self, body: models::Pet) -> Box<Future<Item=AddPetResponse, Error=ApiError> + Send> {
-        self.api.add_pet(body, &self.context)
+        self.api().add_pet(body, &self.context())
     }
 
     /// Deletes a pet
     fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<Future<Item=DeletePetResponse, Error=ApiError> + Send> {
-        self.api.delete_pet(pet_id, api_key, &self.context)
+        self.api().delete_pet(pet_id, api_key, &self.context())
     }
 
     /// Finds Pets by status
     fn find_pets_by_status(&self, status: &Vec<String>) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send> {
-        self.api.find_pets_by_status(status, &self.context)
+        self.api().find_pets_by_status(status, &self.context())
     }
 
     /// Finds Pets by tags
     fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send> {
-        self.api.find_pets_by_tags(tags, &self.context)
+        self.api().find_pets_by_tags(tags, &self.context())
     }
 
     /// Find pet by ID
     fn get_pet_by_id(&self, pet_id: i64) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError> + Send> {
-        self.api.get_pet_by_id(pet_id, &self.context)
+        self.api().get_pet_by_id(pet_id, &self.context())
     }
 
     /// Update an existing pet
     fn update_pet(&self, body: models::Pet) -> Box<Future<Item=UpdatePetResponse, Error=ApiError> + Send> {
-        self.api.update_pet(body, &self.context)
+        self.api().update_pet(body, &self.context())
     }
 
     /// Updates a pet in the store with form data
     fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send> {
-        self.api.update_pet_with_form(pet_id, name, status, &self.context)
+        self.api().update_pet_with_form(pet_id, name, status, &self.context())
     }
 
     /// uploads an image
     fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Box<Future<Item=Option<Box<Stream<Item=Vec<u8>, Error=Error> + Send>>, Error=Error> + Send>) -> Box<Future<Item=UploadFileResponse, Error=ApiError> + Send> {
-        self.api.upload_file(pet_id, additional_metadata, file, &self.context)
+        self.api().upload_file(pet_id, additional_metadata, file, &self.context())
     }
 
     /// Delete purchase order by ID
     fn delete_order(&self, order_id: String) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError> + Send> {
-        self.api.delete_order(order_id, &self.context)
+        self.api().delete_order(order_id, &self.context())
     }
 
     /// Returns pet inventories by status
     fn get_inventory(&self) -> Box<Future<Item=GetInventoryResponse, Error=ApiError> + Send> {
-        self.api.get_inventory(&self.context)
+        self.api().get_inventory(&self.context())
     }
 
     /// Find purchase order by ID
     fn get_order_by_id(&self, order_id: i64) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError> + Send> {
-        self.api.get_order_by_id(order_id, &self.context)
+        self.api().get_order_by_id(order_id, &self.context())
     }
 
     /// Place an order for a pet
     fn place_order(&self, body: models::Order) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError> + Send> {
-        self.api.place_order(body, &self.context)
+        self.api().place_order(body, &self.context())
     }
 
     /// Create user
     fn create_user(&self, body: models::User) -> Box<Future<Item=CreateUserResponse, Error=ApiError> + Send> {
-        self.api.create_user(body, &self.context)
+        self.api().create_user(body, &self.context())
     }
 
     /// Creates list of users with given input array
     fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send> {
-        self.api.create_users_with_array_input(body, &self.context)
+        self.api().create_users_with_array_input(body, &self.context())
     }
 
     /// Creates list of users with given input array
     fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send> {
-        self.api.create_users_with_list_input(body, &self.context)
+        self.api().create_users_with_list_input(body, &self.context())
     }
 
     /// Delete user
     fn delete_user(&self, username: String) -> Box<Future<Item=DeleteUserResponse, Error=ApiError> + Send> {
-        self.api.delete_user(username, &self.context)
+        self.api().delete_user(username, &self.context())
     }
 
     /// Get user by user name
     fn get_user_by_name(&self, username: String) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError> + Send> {
-        self.api.get_user_by_name(username, &self.context)
+        self.api().get_user_by_name(username, &self.context())
     }
 
     /// Logs user into the system
     fn login_user(&self, username: String, password: String) -> Box<Future<Item=LoginUserResponse, Error=ApiError> + Send> {
-        self.api.login_user(username, password, &self.context)
+        self.api().login_user(username, password, &self.context())
     }
 
     /// Logs out current logged in user session
     fn logout_user(&self) -> Box<Future<Item=LogoutUserResponse, Error=ApiError> + Send> {
-        self.api.logout_user(&self.context)
+        self.api().logout_user(&self.context())
     }
 
     /// Updated user
     fn update_user(&self, username: String, body: models::User) -> Box<Future<Item=UpdateUserResponse, Error=ApiError> + Send> {
-        self.api.update_user(username, body, &self.context)
-    }
-
-}
-
-impl<T: ApiNoContext> Api for T {
-
-
-    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>, _: &Context) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send> {
-        self.fake_outer_boolean_serialize(body, )
-    }
-
-
-    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>, _: &Context) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send> {
-        self.fake_outer_composite_serialize(body, )
-    }
-
-
-    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>, _: &Context) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send> {
-        self.fake_outer_number_serialize(body, )
-    }
-
-
-    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, _: &Context) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send> {
-        self.fake_outer_string_serialize(body, )
-    }
-
-    /// To test \"client\" model
-    fn test_client_model(&self, body: models::Client, _: &Context) -> Box<Future<Item=TestClientModelResponse, Error=ApiError> + Send> {
-        self.test_client_model(body, )
-    }
-
-    /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>, _: &Context) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send> {
-        self.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, )
-    }
-
-    /// To test enum parameters
-    fn test_enum_parameters(&self, enum_form_string_array: Option<&Vec<String>>, enum_form_string: Option<String>, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, _: &Context) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError> + Send> {
-        self.test_enum_parameters(enum_form_string_array, enum_form_string, enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, )
-    }
-
-    /// test json serialization of form data
-    fn test_json_form_data(&self, param: String, param2: String, _: &Context) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send> {
-        self.test_json_form_data(param, param2, )
-    }
-
-    /// To test class name in snake case
-    fn test_classname(&self, body: models::Client, _: &Context) -> Box<Future<Item=TestClassnameResponse, Error=ApiError> + Send> {
-        self.test_classname(body, )
-    }
-
-    /// Add a new pet to the store
-    fn add_pet(&self, body: models::Pet, _: &Context) -> Box<Future<Item=AddPetResponse, Error=ApiError> + Send> {
-        self.add_pet(body, )
-    }
-
-    /// Deletes a pet
-    fn delete_pet(&self, pet_id: i64, api_key: Option<String>, _: &Context) -> Box<Future<Item=DeletePetResponse, Error=ApiError> + Send> {
-        self.delete_pet(pet_id, api_key, )
-    }
-
-    /// Finds Pets by status
-    fn find_pets_by_status(&self, status: &Vec<String>, _: &Context) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send> {
-        self.find_pets_by_status(status, )
-    }
-
-    /// Finds Pets by tags
-    fn find_pets_by_tags(&self, tags: &Vec<String>, _: &Context) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send> {
-        self.find_pets_by_tags(tags, )
-    }
-
-    /// Find pet by ID
-    fn get_pet_by_id(&self, pet_id: i64, _: &Context) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError> + Send> {
-        self.get_pet_by_id(pet_id, )
-    }
-
-    /// Update an existing pet
-    fn update_pet(&self, body: models::Pet, _: &Context) -> Box<Future<Item=UpdatePetResponse, Error=ApiError> + Send> {
-        self.update_pet(body, )
-    }
-
-    /// Updates a pet in the store with form data
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>, _: &Context) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send> {
-        self.update_pet_with_form(pet_id, name, status, )
-    }
-
-    /// uploads an image
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Box<Future<Item=Option<Box<Stream<Item=Vec<u8>, Error=Error> + Send>>, Error=Error> + Send>, _: &Context) -> Box<Future<Item=UploadFileResponse, Error=ApiError> + Send> {
-        self.upload_file(pet_id, additional_metadata, file, )
-    }
-
-    /// Delete purchase order by ID
-    fn delete_order(&self, order_id: String, _: &Context) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError> + Send> {
-        self.delete_order(order_id, )
-    }
-
-    /// Returns pet inventories by status
-    fn get_inventory(&self, _: &Context) -> Box<Future<Item=GetInventoryResponse, Error=ApiError> + Send> {
-        self.get_inventory()
-    }
-
-    /// Find purchase order by ID
-    fn get_order_by_id(&self, order_id: i64, _: &Context) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError> + Send> {
-        self.get_order_by_id(order_id, )
-    }
-
-    /// Place an order for a pet
-    fn place_order(&self, body: models::Order, _: &Context) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError> + Send> {
-        self.place_order(body, )
-    }
-
-    /// Create user
-    fn create_user(&self, body: models::User, _: &Context) -> Box<Future<Item=CreateUserResponse, Error=ApiError> + Send> {
-        self.create_user(body, )
-    }
-
-    /// Creates list of users with given input array
-    fn create_users_with_array_input(&self, body: &Vec<models::User>, _: &Context) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send> {
-        self.create_users_with_array_input(body, )
-    }
-
-    /// Creates list of users with given input array
-    fn create_users_with_list_input(&self, body: &Vec<models::User>, _: &Context) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send> {
-        self.create_users_with_list_input(body, )
-    }
-
-    /// Delete user
-    fn delete_user(&self, username: String, _: &Context) -> Box<Future<Item=DeleteUserResponse, Error=ApiError> + Send> {
-        self.delete_user(username, )
-    }
-
-    /// Get user by user name
-    fn get_user_by_name(&self, username: String, _: &Context) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError> + Send> {
-        self.get_user_by_name(username, )
-    }
-
-    /// Logs user into the system
-    fn login_user(&self, username: String, password: String, _: &Context) -> Box<Future<Item=LoginUserResponse, Error=ApiError> + Send> {
-        self.login_user(username, password, )
-    }
-
-    /// Logs out current logged in user session
-    fn logout_user(&self, _: &Context) -> Box<Future<Item=LogoutUserResponse, Error=ApiError> + Send> {
-        self.logout_user()
-    }
-
-    /// Updated user
-    fn update_user(&self, username: String, body: models::User, _: &Context) -> Box<Future<Item=UpdateUserResponse, Error=ApiError> + Send> {
-        self.update_user(username, body, )
+        self.api().update_user(username, body, &self.context())
     }
 
 }


### PR DESCRIPTION
In some cases, it can be a bit painful having to pass `Context` to every `Api` function call.  This pull request adds

*   a `with_context(Context)` function to every `Api`-implementing struct, which returns
*   a struct (`ContextWrapper`) implementing `ApiNoContext`, which has the same methods but without the Context parameter (as the previously-provided one is used instead).

For example...

```rust
let client = petstore_api::Client::try_new_http("http://localhost:8080").expect("Failed to create HTTP client");
let client = client.with_context(petstore_api::Context::new_with_span_id(self::uuid::Uuid::new_v4().to_string()));

let result = client.fake_outer_boolean_serialize(None).wait(); // Note: no Context required.
```