### PR TITLE
Support generate's "--reserved-words-mappings" option

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
@@ -275,7 +275,10 @@ public class Rust2Codegen extends DefaultCodegen implements CodegenConfig {
      */
     @Override
     public String escapeReservedWord(String name) {
-        return "_" + name;  // add an underscore to the name
+        if (this.reservedWordsMappings().containsKey(name)) {
+            return this.reservedWordsMappings().get(name);
+        }
+        return "_" + name; // add an underscore to the name
     }
 
     /**


### PR DESCRIPTION
This is a redo of https://github.com/Metaswitch/swagger-codegen-not-forked/pull/7